### PR TITLE
Use trusted publisher for PyPi

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,14 @@
+name: dependabot-auto-merge
+on: [pull_request_target]
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Dependabot Auto Merge
+        uses: ahmadnassri/action-dependabot-auto-merge@v2.6.6
+        with:
+          github-token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,5 +24,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel build
           python -m build
-      - name: Publish a Python distribution to PyPI
+      - name: Publish a Python distribution to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,3 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 name: Upload Python Package
 
 on:
@@ -10,9 +7,12 @@ on:
     types: [published]
 
 jobs:
-  deploy:
+  pypi-publish:
     runs-on: ubuntu-latest
-
+    name: Upload release to PyPi
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -26,5 +26,3 @@ jobs:
           python -m build
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  python:
+  ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Description

Using trusted publishers (OIDC) to publish to PyPi. Also added a workflow for automatically merging dependabot PRs.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary

### Additional Comments

Anything else you'd like to add.
